### PR TITLE
Improve: fixes in entity change and additional methods for activity scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.1.1] - 2024-08-07
+
+### Added
+
+- Enrich with object (also includes support of anonymous types)
+- Enrich with dictionary
+- Ability to add activity without creating context (`IActivityScope.Add` method)
+- Default ActivitySaveChangesInterceptor
+- Added ability to modified entity values equality
+
+### Fixed
+
+- Enrich with DateOnly, TimeOnly, DateTime, DateTimeOffset, TimeSpan, Uri
+
+### Changed
+
+- Delete EntityChange doesn't contain OriginalValues anymore, Values would be filled in with OriginalValues
+
+## [2.1.0-rc1] - 2024-04-19
+
+### Added
+
+- EntityFrameworkCore entity change interceptors

--- a/src/Webinex.Activity.Abstractions/ActivityExtensions.cs
+++ b/src/Webinex.Activity.Abstractions/ActivityExtensions.cs
@@ -1,67 +1,91 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public static class ActivitiesExtensions
 {
-    public static class ActivitiesExtensions
+    public static IActivity[] All(this IActivityScope activityScope)
     {
-        public static IActivity[] All([NotNull] this IActivityScope activityScope)
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+        return activityScope.Root.SelectMany(x => WithFlattenChildren(x)).ToArray();
+    }
+
+    public static ActivityPathItem[] Path(this IActivityScope activityScope)
+    {
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+        var current = activityScope.Current;
+        if (current == null) return Array.Empty<ActivityPathItem>();
+
+        var path = new LinkedList<ActivityPathItem>();
+        var all = activityScope.All().ToDictionary(x => x.Id);
+        var pointer = current;
+
+        while (pointer != null)
         {
-            activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
-            return activityScope.Root.SelectMany(x => WithFlattenChildren(x)).ToArray();
-        }
+            path.AddLast(new ActivityPathItem(pointer.Id, pointer.Kind));
 
-        public static ActivityPathItem[] Path([NotNull] this IActivityScope activityScope)
-        {
-            activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
-            var current = activityScope.Current;
-            if (current == null) return Array.Empty<ActivityPathItem>();
-
-            var path = new LinkedList<ActivityPathItem>();
-            var all = activityScope.All().ToDictionary(x => x.Id);
-            var pointer = current;
-
-            while (pointer != null)
+            if (pointer.ParentId == null || !all.ContainsKey(pointer.ParentId))
             {
-                path.AddLast(new ActivityPathItem(pointer.Id, pointer.Kind));
-
-                if (pointer.ParentId == null || !all.ContainsKey(pointer.ParentId))
-                {
-                    pointer = null;
-                    continue;
-                }
-
-                pointer = all[pointer.ParentId];
+                pointer = null;
+                continue;
             }
 
-            var result = path.Reverse().ToArray();
-            return activityScope.OutboundPath.Concat(result).ToArray();
+            pointer = all[pointer.ParentId];
         }
 
-        public static IActivity? FindLastNotCompleted([NotNull] this IActivityScope activityScope)
-        {
-            return FindLastNotCompleted(activityScope.Root);
-        }
+        var result = path.Reverse().ToArray();
+        return activityScope.OutboundPath.Concat(result).ToArray();
+    }
 
-        private static IActivity? FindLastNotCompleted(IEnumerable<IActivity> activities)
-        {
-            var notCompleted = activities.LastOrDefault(x => !x.Completed);
+    public static IActivity? FindLastNotCompleted(this IActivityScope activityScope)
+    {
+        return FindLastNotCompleted(activityScope.Root);
+    }
 
-            return notCompleted == null
-                ? null
-                : FindLastNotCompleted(notCompleted.Children) ?? notCompleted;
-        }
+    private static IActivity? FindLastNotCompleted(IEnumerable<IActivity> activities)
+    {
+        var notCompleted = activities.LastOrDefault(x => !x.Completed);
 
-        public static IEnumerable<IActivity> WithFlattenChildren([NotNull] this IActivity activity)
-        {
-            activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        return notCompleted == null
+            ? null
+            : FindLastNotCompleted(notCompleted.Children) ?? notCompleted;
+    }
 
-            if (!activity.Children.Any())
-                return new[] { activity };
+    public static IEnumerable<IActivity> WithFlattenChildren(this IActivity activity)
+    {
+        activity = activity ?? throw new ArgumentNullException(nameof(activity));
 
-            return activity.Children.SelectMany(WithFlattenChildren).Append(activity);
-        }
+        if (!activity.Children.Any())
+            return new[] { activity };
+
+        return activity.Children.SelectMany(WithFlattenChildren).Append(activity);
+    }
+
+    public static IActivity Enrich(this IActivity activity, string path, object? val)
+    {
+        activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        path = path ?? throw new ArgumentNullException(nameof(path));
+
+        activity.Values.Enrich(path, val);
+        return activity;
+    }
+
+    public static IActivity Enrich(this IActivity activity, object value)
+    {
+        activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+        activity.Values.Enrich(value);
+        return activity;
+    }
+
+    public static IActivity Enrich(this IActivity activity, IDictionary dictionary)
+    {
+        activity = activity ?? throw new ArgumentNullException(nameof(activity));
+        dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        activity.Values.Enrich(dictionary);
+        return activity;
     }
 }

--- a/src/Webinex.Activity.Abstractions/ActivityScopeExtensions.cs
+++ b/src/Webinex.Activity.Abstractions/ActivityScopeExtensions.cs
@@ -1,23 +1,69 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Collections;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public static class ActivityScopeExtensions
 {
-    public static class ActivityScopeExtensions
+    public static IActivityScope Enrich(
+        this IActivityScope activityScope,
+        string path,
+        object? value)
     {
-        public static IActivityScope Enrich(
-            [NotNull] this IActivityScope activityScope,
-            [NotNull] string path,
-            object value)
-        {
-            activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
-            path = path ?? throw new ArgumentNullException(nameof(path));
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+        path = path ?? throw new ArgumentNullException(nameof(path));
 
-            if (activityScope.Current == null)
-                throw new InvalidOperationException("No current action");
+        if (!activityScope.Initialized)
+            throw new InvalidOperationException("Activity scope not initialized");
 
-            activityScope.Current.Enrich(path, value);
-            return activityScope;
-        }
+        activityScope.Current!.Enrich(path, value);
+        return activityScope;
+    }
+
+    public static IActivityScope Enrich(this IActivityScope activityScope, object value)
+    {
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+
+        if (!activityScope.Initialized)
+            throw new InvalidOperationException("Activity scope not initialized");
+
+        activityScope.Current!.Enrich(value);
+        return activityScope;
+    }
+
+    public static IActivityScope Enrich(this IActivityScope activityScope, IDictionary dictionary)
+    {
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+
+        if (!activityScope.Initialized)
+            throw new InvalidOperationException("Activity scope not initialized");
+
+        activityScope.Current!.Enrich(dictionary);
+        return activityScope;
+    }
+
+    public static IActivityScope Add(this IActivityScope activityScope, string kind, object value)
+    {
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+        kind = kind ?? throw new ArgumentNullException(nameof(kind));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+
+        if (!activityScope.Initialized)
+            throw new InvalidOperationException("Activity scope not initialized");
+        
+        return activityScope.Add(kind, activity => activity.Enrich(value));
+    }
+
+    public static IActivityScope Add(this IActivityScope activityScope, string kind, IDictionary value)
+    {
+        activityScope = activityScope ?? throw new ArgumentNullException(nameof(activityScope));
+        kind = kind ?? throw new ArgumentNullException(nameof(kind));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+
+        if (!activityScope.Initialized)
+            throw new InvalidOperationException("Activity scope not initialized");
+        
+        activityScope.Add(kind, activity => activity.Enrich(value));
+        return activityScope;
     }
 }

--- a/src/Webinex.Activity.Abstractions/IActivity.cs
+++ b/src/Webinex.Activity.Abstractions/IActivity.cs
@@ -1,19 +1,12 @@
 ﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public interface IActivity : IActivityValue
 {
-    // ReSharper disable once PossibleInterfaceMemberAmbiguity
-    public interface IActivity : IActivityValue
-    {
-        [NotNull] IDictionary<string, object> Meta { get; }
-
-        [NotNull] IEnumerable<IActivity> Children { get; }
-        
-        [NotNull] new IMutableActivitySystemValues SystemValues { get; }
-        
-        bool Completed { get; }
-
-        void Complete(bool? success = null);
-    }
+    IDictionary<string, object> Meta { get; }
+    IEnumerable<IActivity> Children { get; }
+    new IMutableActivitySystemValues SystemValues { get; }
+    bool Completed { get; }
+    void Complete(bool? success = null);
 }

--- a/src/Webinex.Activity.Abstractions/IActivityContext.cs
+++ b/src/Webinex.Activity.Abstractions/IActivityContext.cs
@@ -1,10 +1,9 @@
 ﻿using System.Collections.Generic;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public interface IActivityContext : IActivityContextValue
 {
-    public interface IActivityContext : IActivityContextValue
-    {
-        new IMutableActivitySystemValues SystemValues { get; }
-        IDictionary<string, object> Meta { get; }
-    }
+    new IMutableActivitySystemValues SystemValues { get; }
+    IDictionary<string, object> Meta { get; }
 }

--- a/src/Webinex.Activity.Abstractions/IActivityScope.cs
+++ b/src/Webinex.Activity.Abstractions/IActivityScope.cs
@@ -1,17 +1,18 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public interface IActivityScope
 {
-    public interface IActivityScope
-    {
-        IActivity? Current { get; }
-        IActivityContext Context { get; }
-        ActivityPathItem[] OutboundPath { get; }
-        IEnumerable<IActivity> Root { get; }
-        IDisposableActivity Push(string kind);
-        Task CompleteAsync(bool success = true);
-        IActivityBatchValue ToBatch();
-    }
+    bool Initialized { get; }
+    IActivity? Current { get; }
+    IActivityContext Context { get; }
+    ActivityPathItem[] OutboundPath { get; }
+    IEnumerable<IActivity> Root { get; }
+    IDisposableActivity Push(string kind);
+    IActivityScope Add(string kind, Action<IActivity>? action = null);
+    Task CompleteAsync(bool success = true);
+    IActivityBatchValue ToBatch();
 }

--- a/src/Webinex.Activity.Abstractions/IDisposableActivity.cs
+++ b/src/Webinex.Activity.Abstractions/IDisposableActivity.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public interface IDisposableActivity : IActivity, IDisposable
 {
-    public interface IDisposableActivity : IActivity, IDisposable
-    {
-    }
 }

--- a/src/Webinex.Activity.Abstractions/Webinex.Activity.Abstractions.csproj
+++ b/src/Webinex.Activity.Abstractions/Webinex.Activity.Abstractions.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>Webinex.Activity.Abstractions</PackageId>
     <RootNamespace>Webinex.Activity</RootNamespace>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Webinex.Activity.All/Package.props
+++ b/src/Webinex.Activity.All/Package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
     <PropertyGroup>
         <Title>Webinex Activity</Title>
-        <PackageVersion>2.1.0-rc1</PackageVersion>
+        <PackageVersion>2.1.1</PackageVersion>
         <Authors>Webinex Dev</Authors>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Webinex.Activity.Core/ActivityScope.cs
+++ b/src/Webinex.Activity.Core/ActivityScope.cs
@@ -40,6 +40,7 @@ namespace Webinex.Activity
             });
         }
 
+        public bool Initialized => true;
         public IActivity? Current => this.FindLastNotCompleted();
 
         public IActivityContext Context => _contextLazy.Value;
@@ -58,6 +59,13 @@ namespace Webinex.Activity
                 _root.AddLast(activity);
 
             return activity;
+        }
+
+        public IActivityScope Add(string kind, Action<IActivity>? action = null)
+        {
+using var _ = Push(kind);
+            action?.Invoke(Current!);
+            return this;
         }
 
         public async Task CompleteAsync(bool success = true)

--- a/src/Webinex.Activity.Core/ActivityScopeAccessor.cs
+++ b/src/Webinex.Activity.Core/ActivityScopeAccessor.cs
@@ -34,6 +34,7 @@ namespace Webinex.Activity
         public IActivityScope RequiredValue =>
             Value ?? throw new InvalidOperationException("Activity scope not provided");
 
+        public bool Initialized => Value != null;
         public IActivity? Current => RequiredValue.Current;
 
         public IActivityContext Context => RequiredValue.Context;
@@ -45,6 +46,11 @@ namespace Webinex.Activity
         public IDisposableActivity Push(string kind)
         {
             return RequiredValue.Push(kind);
+        }
+
+        public IActivityScope Add(string kind, Action<IActivity>? action = null)
+        {
+            return RequiredValue.Add(kind, action);
         }
 
         public Task CompleteAsync(bool success = true)

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/DataAccess/User.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/DataAccess/User.cs
@@ -31,7 +31,7 @@ public class User
         Name = name;
     }
 
-    public void ReplacePhone(Phone phone)
+    public void ReplacePrimaryPhone(Phone phone)
     {
         Contact = new Contact(phone.Clone(), Contact.AdditionalPhone?.Clone());
     }

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/InterceptorUpdateTestBase.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/InterceptorUpdateTestBase.cs
@@ -20,8 +20,10 @@ public abstract class InterceptorUpdateTestBase : InterceptorTestBase
 
     private User Initial { get; set; } = null!;
     protected User? InStorage { get; private set; }
+
+    protected virtual bool IsValuesEqual => false;
     
-    private EntityChange Result => ProcessCalls.ElementAt(1).ElementAt(0);
+    protected EntityChange Result => ProcessCalls.ElementAt(1).ElementAt(0);
     
     [Test]
     public void ShouldBeTwoCalls()
@@ -36,6 +38,12 @@ public abstract class InterceptorUpdateTestBase : InterceptorTestBase
         var expected =
             User.EntityChange(EntityChangeType.Updated, InStorage!.Id, expectedValues, InStorageInitialValues);
         Result.Should().BeEquivalentTo(expected);
+    }
+    
+    [Test]
+    public void IsValuesEqual_ShouldBeExpectedValue()
+    {
+        Result.IsValuesEqual().Should().Be(IsValuesEqual);
     }
 
     [SetUp]

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenComplexChange.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenComplexChange.cs
@@ -37,7 +37,7 @@ public class WhenComplexChange : InterceptorTestBase
     {
         var result = Result.Single(x => x.Type == EntityChangeType.Deleted);
         var expected = User.EntityChange(EntityChangeType.Deleted, _toDelete.Id, _initialToDeleteValues,
-            _initialToDeleteValues);
+            null);
 
         result.Should().BeEquivalentTo(expected);
     }

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenEntityDeleted.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenEntityDeleted.cs
@@ -24,7 +24,7 @@ public class WhenEntityDeleted : InterceptorTestBase
             EntityChangeType.Deleted,
             _user.Id,
             _user.Values(),
-            _user.Values());
+            null);
 
         Result.Should().BeEquivalentTo(expected);
     }

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplaceAndHasEntitiesReferences.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplaceAndHasEntitiesReferences.cs
@@ -59,7 +59,7 @@ public class WhenOwnsOneReplaceAndHasEntitiesReferences : InterceptorTestBase
             var inStorage = await dbContext.Users.FindAsync(_user.Id);
             inStorage = inStorage ?? throw new InvalidOperationException();
             _inStorageInitialValues = inStorage.Values();
-            inStorage.ReplacePhone(_newPhone);
+            inStorage.ReplacePrimaryPhone(_newPhone);
             await dbContext.SaveChangesAsync();
         }
     }

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplaced.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplaced.cs
@@ -16,7 +16,7 @@ public class WhenOwnsOneReplaced : InterceptorUpdateTestBase
 
     protected override void OnUpdate(User user)
     {
-        user.ReplacePhone(_newPhone);
+        user.ReplacePrimaryPhone(_newPhone);
     }
 
     protected override IDictionary<string, object?> ExpectedValues()

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplacedButNotChanged.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplacedButNotChanged.cs
@@ -1,0 +1,20 @@
+﻿using Webinex.Activity.EntityFrameworkCore.Tests.DataAccess;
+using Webinex.Activity.EntityFrameworkCore.Tests.Extensions;
+
+namespace Webinex.Activity.EntityFrameworkCore.Tests.InterceptorTests;
+
+[TestFixture]
+public class WhenOwnsOneReplacedButNotChanged : InterceptorUpdateTestBase
+{
+    protected override bool IsValuesEqual => true;
+
+    protected override void OnUpdate(User user)
+    {
+        user.ReplacePrimaryPhone(new Phone(user.Contact.PrimaryPhone.Value));
+    }
+
+    protected override IDictionary<string, object?> ExpectedValues()
+    {
+        return InStorageInitialValues.CloneValues();
+    }
+}

--- a/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplacedTwice.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore.Tests/InterceptorTests/WhenOwnsOneReplacedTwice.cs
@@ -16,8 +16,8 @@ public class WhenOwnsOneReplacedTwice : InterceptorUpdateTestBase
 
     protected override void OnUpdate(User user)
     {
-        user.ReplacePhone(Phone.Random());
-        user.ReplacePhone(_newPhone);
+        user.ReplacePrimaryPhone(Phone.Random());
+        user.ReplacePrimaryPhone(_newPhone);
     }
 
     protected override IDictionary<string, object?> ExpectedValues()

--- a/src/Webinex.Activity.EntityFrameworkCore/ActivityEntityFrameworkCoreServiceCollectionExtensions.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/ActivityEntityFrameworkCoreServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Webinex.Activity.EntityFrameworkCore;
+
+public static class ActivityEntityFrameworkCoreServiceCollectionExtensions
+{
+    public static IServiceCollection AddDefaultActivitySaveChangesSubscriber(
+        this IServiceCollection services,
+        Action<IDefaultActivitySaveChangesConfiguration>? configure = null)
+    {
+        var settings = new DefaultActivitySaveChangesSubscriberSettings();
+        configure?.Invoke(settings);
+        services.AddSingleton(settings);
+        return services.AddScoped<IActivitySaveChangesSubscriber, DefaultActivitySaveChangesSubscriber>();
+    }
+}

--- a/src/Webinex.Activity.EntityFrameworkCore/DefaultActivitySaveChangesSubscriber.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/DefaultActivitySaveChangesSubscriber.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Webinex.Activity.EntityFrameworkCore;
+
+internal class DefaultActivitySaveChangesSubscriber : IActivitySaveChangesSubscriber
+{
+    private readonly IActivityScope _activityScope;
+    private readonly DefaultActivitySaveChangesSubscriberSettings _settings;
+
+    public DefaultActivitySaveChangesSubscriber(IActivityScope activityScope,
+        DefaultActivitySaveChangesSubscriberSettings settings)
+    {
+        _activityScope = activityScope;
+        _settings = settings;
+    }
+
+    public Task ProcessAsync(DbContext dbContext, IEnumerable<EntityChange> entityChanges,
+        CancellationToken cancellationToken)
+    {
+        if (!_activityScope.Initialized)
+            return Task.CompletedTask;
+
+        if (_settings.SkipEqualValues)
+            entityChanges = entityChanges.Where(x => x.Type != EntityChangeType.Updated || !x.IsValuesEqual())
+                .ToArray();
+
+        if (!entityChanges.Any())
+            return Task.CompletedTask;
+
+        using var _ = _activityScope.Push(_settings.Kind);
+        _activityScope.Enrich(_settings.ValuePath, entityChanges);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Webinex.Activity.EntityFrameworkCore/DefaultActivitySaveChangesSubscriberSettings.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/DefaultActivitySaveChangesSubscriberSettings.cs
@@ -1,0 +1,37 @@
+﻿namespace Webinex.Activity.EntityFrameworkCore;
+
+public interface IDefaultActivitySaveChangesConfiguration
+{
+    string Kind { get; }
+    string ValuePath { get; }
+    bool SkipEqualValues { get; }
+
+    IDefaultActivitySaveChangesConfiguration UseKind(string kind);
+    IDefaultActivitySaveChangesConfiguration UseValuePath(string path);
+    IDefaultActivitySaveChangesConfiguration UseSkipEqualValues(bool value);
+}
+
+internal class DefaultActivitySaveChangesSubscriberSettings : IDefaultActivitySaveChangesConfiguration
+{
+    public string Kind { get; private set; } = "DataChange";
+    public string ValuePath { get; private set; } = "$dataChange";
+    public bool SkipEqualValues { get; private set; } = true;
+
+    public IDefaultActivitySaveChangesConfiguration UseKind(string kind)
+    {
+        Kind = kind ?? throw new ArgumentNullException(kind);
+        return this;
+    }
+
+    public IDefaultActivitySaveChangesConfiguration UseValuePath(string path)
+    {
+        ValuePath = path ?? throw new ArgumentNullException(path);
+        return this;
+    }
+
+    public IDefaultActivitySaveChangesConfiguration UseSkipEqualValues(bool value)
+    {
+        SkipEqualValues = value;
+        return this;
+    }
+}

--- a/src/Webinex.Activity.EntityFrameworkCore/EntityChange.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/EntityChange.cs
@@ -1,4 +1,6 @@
-﻿namespace Webinex.Activity.EntityFrameworkCore;
+﻿using Webinex.Activity.EntityFrameworkCore.Utils;
+
+namespace Webinex.Activity.EntityFrameworkCore;
 
 public class EntityChange
 {
@@ -18,4 +20,13 @@ public class EntityChange
     public IDictionary<string, object?>? PrimaryKey { get; }
     public IDictionary<string, object?> Values { get; }
     public IDictionary<string, object?>? OriginalValues { get; }
+
+    public bool IsValuesEqual()
+    {
+        if (OriginalValues == null)
+            return false;
+        
+        return ValuesUtil.IsEqual(new Dictionary<string, object?>(Values),
+            new Dictionary<string, object?>(OriginalValues));
+    }
 }

--- a/src/Webinex.Activity.EntityFrameworkCore/Utils/FindOwnerUtil.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/Utils/FindOwnerUtil.cs
@@ -25,8 +25,16 @@ internal static class FindOwnerUtil
 
         bool IsPrincipalKeyMatch(EntityEntry x) => PrincipalKeyValuesSelector(x).SequenceEqual(foreignKeyValues);
 
-        return entry.Context.ChangeTracker
+        var owner = entry.Context.ChangeTracker
             .Entries()
             .FirstOrDefault(x => x.Metadata == ownership.PrincipalEntityType && IsPrincipalKeyMatch(x) && x.State == state);
+
+        if (owner == null)
+            return null;
+
+        if (!owner.Metadata.IsOwned())
+            return owner;
+
+        return FindEntity(owner, state);
     }
 }

--- a/src/Webinex.Activity.EntityFrameworkCore/Utils/ValuesUtil.cs
+++ b/src/Webinex.Activity.EntityFrameworkCore/Utils/ValuesUtil.cs
@@ -1,0 +1,64 @@
+﻿namespace Webinex.Activity.EntityFrameworkCore.Utils;
+
+internal static class ValuesUtil
+{
+    public static bool IsEqual(IDictionary<string, object?>? x, IDictionary<string, object?>? y)
+    {
+        if (x == null && y == null)
+            return true;
+        
+        if (x == null || y == null)
+            return false;
+        
+        if (x.Count != y.Count)
+            return true;
+
+        foreach (var xKey in x.Keys)
+        {
+            if (!y.ContainsKey(xKey))
+                return false;
+
+            var xValue = x[xKey];
+            var yValue = y[xKey];
+
+            if (xValue == null && yValue == null)
+                continue;
+
+            if (xValue == null || yValue == null)
+                return false;
+
+            if (xValue.GetType() != yValue.GetType())
+                return false;
+            
+            if (xValue is IDictionary<string, object?> xDictionary)
+            {
+                if (!IsEqual(xDictionary, (IDictionary<string, object?>)y[xKey]!))
+                    return false;
+                
+                continue;
+            }
+
+            if (xValue is IEnumerable<IDictionary<string, object?>> xEnumerable)
+            {
+                xEnumerable = xEnumerable.ToArray();
+                var yEnumerable = ((IEnumerable<IDictionary<string, object?>>)yValue).ToArray();
+                
+                if (xEnumerable.Count() != yEnumerable.Length)
+                    return false;
+
+                for (var index = 0; index < xEnumerable.Count(); index++)
+                {
+                    if (!IsEqual(xEnumerable.ElementAt(index), yEnumerable[index]))
+                        return false;
+                }
+                
+                continue;
+            }
+
+            if (!xValue.Equals(yValue))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Webinex.Activity.EntityFrameworkCore/Webinex.Activity.EntityFrameworkCore.csproj
+++ b/src/Webinex.Activity.EntityFrameworkCore/Webinex.Activity.EntityFrameworkCore.csproj
@@ -12,4 +12,8 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Webinex.Activity.Abstractions\Webinex.Activity.Abstractions.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/Webinex.Activity.Tests/ActivityValuesTests.cs
+++ b/src/Webinex.Activity.Tests/ActivityValuesTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Shouldly;
@@ -6,7 +7,7 @@ namespace Webinex.Activity.Tests;
 
 public class ActivityValuesTests
 {
-    private ActivityValues _subject;
+    private ActivityValues _subject = null!;
 
     [Test]
     public void WhenPlainString_ShouldBeOk()
@@ -46,6 +47,13 @@ public class ActivityValuesTests
     }
 
     [Test]
+    public void WhenNull_ShouldBeOk()
+    {
+        _subject.Enrich("value", null);
+        _subject.Get<object?>("value").ShouldBe(null);
+    }
+
+    [Test]
     public void WhenNullValue_ShouldBeOk()
     {
         _subject.Enrich("obj1.array[0].value", null);
@@ -74,9 +82,194 @@ public class ActivityValuesTests
         _subject.Get<int>("obj1.value").ShouldBe(1);
     }
 
+    [Test]
+    public void WhenDictionaryValue_ShouldBeOk()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["value1"] = 1,
+            ["Value2"] = "Value 2",
+            ["value3"] = null,
+        };
+
+        _subject.Enrich("value", value);
+        _subject.Get<int>("value.value1").ShouldBe(1);
+        _subject.Get<string>("value.Value2").ShouldBe("Value 2");
+        _subject.Get<object?>("value.value3").ShouldBe(null);
+    }
+
+    [Test]
+    public void WhenDateTimeOffset_ShouldBeOk()
+    {
+        var value = DateTimeOffset.UtcNow;
+        _subject.Enrich("value", value);
+        _subject.Get<DateTimeOffset>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenDateTime_ShouldBeOk()
+    {
+        var value = DateTime.UtcNow;
+        _subject.Enrich("value", value);
+        _subject.Get<DateTime>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenGuid_ShouldBeOk()
+    {
+        var value = Guid.NewGuid();
+        _subject.Enrich("value", value);
+        _subject.Get<Guid>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenTimeSpan_ShouldBeOk()
+    {
+        var value = TimeSpan.FromMinutes(30);
+        _subject.Enrich("value", value);
+        _subject.Get<TimeSpan>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenDateOnly_ShouldBeOk()
+    {
+        var value = DateOnly.FromDateTime(DateTime.Today);
+        _subject.Enrich("value", value);
+        _subject.Get<DateOnly>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenTimeOnly_ShouldBeOk()
+    {
+        var value = TimeOnly.FromDateTime(DateTime.Today);
+        _subject.Enrich("value", value);
+        _subject.Get<TimeOnly>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenUri_ShouldBeOk()
+    {
+        var value = new Uri("https://localhost:3000/api/activity");
+        _subject.Enrich("value", value);
+        _subject.Get<Uri>("value").ShouldBe(value);
+    }
+
+    [Test]
+    public void WhenRootEnrichAnonymousType_PropertyOnly_ShouldBeOk()
+    {
+        var value = new
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            DateOfBirth = DateTimeOffset.UtcNow,
+            Gender = default(DateTimeOffset?),
+        };
+
+        _subject.Enrich(value);
+        _subject.Get<string>("FirstName").ShouldBe(value.FirstName);
+        _subject.Get<string>("LastName").ShouldBe(value.LastName);
+        _subject.Get<DateTimeOffset>("DateOfBirth").ShouldBe(value.DateOfBirth);
+        _subject.Get<object?>("Gender").ShouldBe(null);
+    }
+
+    [Test]
+    public void WhenRootEnrichAnonymousTypeWithObjectValues_PropertyOnly_ShouldBeOk()
+    {
+        var value = new
+        {
+            DateOfBirth = DateTimeOffset.UtcNow,
+            Name = new
+            {
+                FirstName = "James",
+                LastName = "Doe",
+            },
+            Children = new[]
+            {
+                new { Name = "Antony" },
+                new { Name = "Joe" },
+            },
+        };
+
+        _subject.Enrich(value);
+        _subject.Get<DateTimeOffset>("DateOfBirth").ShouldBe(value.DateOfBirth);
+        _subject.Get<string>("Name.FirstName").ShouldBe(value.Name.FirstName);
+        _subject.Get<string>("Name.LastName").ShouldBe(value.Name.LastName);
+        _subject.Get<string>("Children[0].Name").ShouldBe("Antony");
+        _subject.Get<string>("Children[1].Name").ShouldBe("Joe");
+    }
+
+    [Test]
+    public void WhenRootEnrichWithSetOnlyProperties_ShouldBeOk()
+    {
+        var value = new ClassWithSetOnlyProperties
+        {
+            Name = "James Doe",
+            PrivateGet = "Secret Value",
+        };
+
+        _subject.Enrich(value);
+        _subject.Get<string>("Name").ShouldBe(value.Name);
+        _subject.Get<string?>("PrivateGet").ShouldBe(null);
+        _subject.Get<string?>("NoGet").ShouldBe(null);
+        _subject.Get<string?>("Static").ShouldBe(null);
+        _subject.Get<string?>("_noGetValue").ShouldBe(null);
+        _subject.Get<string?>("noGetValue").ShouldBe(null);
+    }
+
+    [Test]
+    public void WhenRootEnrichWithDictionary_ShouldBeOk()
+    {
+        var id = Guid.NewGuid();
+        var dateOfBirth = DateTimeOffset.UtcNow;
+        var joeDateOfBirth = DateTimeOffset.UtcNow.AddDays(-1);
+        var antonyDateOfBirth = DateTimeOffset.UtcNow.AddDays(-53);
+
+        var value = new Dictionary<string, object?>
+        {
+            ["Name"] = new Dictionary<string, object?>
+            {
+                ["FirstName"] = "James",
+                ["LastName"] = "Doe"
+            },
+            ["Children"] = new[]
+            {
+                new Dictionary<string, object?> { ["Name"] = "Antony", ["DateOfBirth"] = antonyDateOfBirth },
+                new Dictionary<string, object?> { ["Name"] = "Joe", ["DateOfBirth"] = joeDateOfBirth },
+            },
+            ["DateOfBirth"] = dateOfBirth,
+            ["Id"] = id,
+            ["Null"] = null,
+        };
+
+        _subject.Enrich(value);
+        _subject.Get<string>("Name.FirstName").ShouldBe("James");
+        _subject.Get<string>("Name.LastName").ShouldBe("Doe");
+        _subject.Get<string>("Children[0].Name").ShouldBe("Antony");
+        _subject.Get<DateTimeOffset>("Children[0].DateOfBirth").ShouldBe(antonyDateOfBirth);
+        _subject.Get<string>("Children[1].Name").ShouldBe("Joe");
+        _subject.Get<DateTimeOffset>("Children[1].DateOfBirth").ShouldBe(joeDateOfBirth);
+        _subject.Get<DateTimeOffset>("DateOfBirth").ShouldBe(dateOfBirth);
+        _subject.Get<Guid>("Id").ShouldBe(id);
+        _subject.Get<object?>("Null").ShouldBe(null);
+    }
+
     [SetUp]
     public void SetUp()
     {
         _subject = new ActivityValues();
+    }
+
+    private class ClassWithSetOnlyProperties
+    {
+        private string? _noGetValue;
+
+        public static string Static { get; set; } = Guid.NewGuid().ToString();
+        public string Name { get; init; }
+        public string PrivateGet { private get; init; }
+
+        public string? NoGet
+        {
+            init => _noGetValue = value;
+        }
     }
 }

--- a/src/Webinex.Activity.Tests/Webinex.Activity.Tests.csproj
+++ b/src/Webinex.Activity.Tests/Webinex.Activity.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Webinex.Activity.Values/ActivityValueExtensions.cs
+++ b/src/Webinex.Activity.Values/ActivityValueExtensions.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections;
+
+namespace Webinex.Activity;
+
+public static class ActivityValueExtensions
+{
+    public static T? Get<T>(this IActivityValue value, string path, T? defaultValue = default)
+    {
+        value = value ?? throw new ArgumentNullException(nameof(value));
+        path = path ?? throw new ArgumentNullException(nameof(path));
+
+        return value.Values.Get(path, defaultValue);
+    }
+
+    public static void Enrich(this IActivityValue activityValue, string path, object? val)
+    {
+        activityValue = activityValue ?? throw new ArgumentNullException(nameof(activityValue));
+        path = path ?? throw new ArgumentNullException(nameof(path));
+
+        activityValue.Values.Enrich(path, val);
+    }
+
+    public static void Enrich(this IActivityValue activityValue, object value)
+    {
+        activityValue = activityValue ?? throw new ArgumentNullException(nameof(activityValue));
+        value = value ?? throw new ArgumentNullException(nameof(value));
+        activityValue.Values.Enrich(value);
+    }
+
+    public static void Enrich(this IActivityValue activityValue, IDictionary dictionary)
+    {
+        activityValue = activityValue ?? throw new ArgumentNullException(nameof(activityValue));
+        dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+        activityValue.Values.Enrich(dictionary);
+    }
+}

--- a/src/Webinex.Activity.Values/ActivityValues.cs
+++ b/src/Webinex.Activity.Values/ActivityValues.cs
@@ -1,174 +1,232 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
+using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-namespace Webinex.Activity
+namespace Webinex.Activity;
+
+public class ActivityValues
 {
-    public class ActivityValues
+    private bool _frozen;
+
+    private static readonly Type[] PrimitiveSerializableReferenceTypes =
+    [
+        typeof(string), typeof(Guid), typeof(DateTime), typeof(DateTimeOffset), typeof(TimeSpan), typeof(Uri),
+        typeof(DateOnly), typeof(TimeOnly)
+    ];
+
+    public ActivityValues(JsonObject? jsonObject = null)
     {
-        private bool _frozen;
+        Value = jsonObject ?? new JsonObject();
+    }
 
-        public ActivityValues(JsonObject? jsonObject = null)
+    internal JsonObject Value { get; }
+
+    public JsonObject AsJsonObject()
+    {
+        var jObject = JsonSerializer.SerializeToNode(Value);
+        return jObject!.AsObject();
+    }
+
+    public static ActivityValues Parse(string value)
+    {
+        return new ActivityValues(JsonSerializer.Deserialize<JsonObject>(value));
+    }
+
+    public static ActivityValues Create(ActivityValueScalar[] flattens)
+    {
+        var result = new ActivityValues();
+        var ordered = flattens
+            .OrderBy(x => x.Path.Pattern)
+            .ThenBy(x => x.Path.Value.Length)
+            .ThenBy(x => x.Path.Value).ToArray();
+
+        foreach (var activityValueFlatten in ordered)
         {
-            Value = jsonObject ?? new JsonObject();
+            result.Enrich(activityValueFlatten.Path.Value, activityValueFlatten.GetValue());
         }
 
-        internal JsonObject Value { get; }
+        return result;
+    }
 
-        public JsonObject AsJsonObject()
+    public void Freeze()
+    {
+        _frozen = true;
+    }
+
+    public ActivityValueScalar[] Flatten()
+    {
+        return ActivityValueFlattener.Flatten(Value);
+    }
+
+    public void Enrich(object value)
+    {
+        if (value == null!)
         {
-            var jObject = JsonSerializer.SerializeToNode(Value);
-            return jObject!.AsObject();
+            throw new InvalidOperationException("Value cannot be null");
         }
 
-        public static ActivityValues Parse(string value)
+        if (IsPrimitive(value))
         {
-            return new ActivityValues(JsonSerializer.Deserialize<JsonObject>(value));
+            throw new InvalidOperationException("Primitive serializable type cannot be used as root value");
         }
 
-        public static ActivityValues Create(ActivityValueScalar[] flattens)
+        if (value is IEnumerable)
         {
-            var result = new ActivityValues();
-            var ordered = flattens
-                .OrderBy(x => x.Path.Pattern)
-                .ThenBy(x => x.Path.Value.Length)
-                .ThenBy(x => x.Path.Value).ToArray();
+            throw new InvalidOperationException("Enumerable type cannot be used as root value");
+        }
 
-            foreach (var activityValueFlatten in ordered)
+        if (value is IDictionary dictionary)
+        {
+            Enrich(dictionary);
+            return;
+        }
+
+        var type = value.GetType();
+
+        var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.GetProperty);
+        foreach (var property in properties)
+        {
+            if (property.GetGetMethod() != null && property.GetGetMethod()!.IsPublic)
+                Enrich(property.Name, property.GetValue(value));
+        }
+    }
+
+    public void Enrich(IDictionary values)
+    {
+        foreach (DictionaryEntry entry in values)
+        {
+            if (entry.Key.ToString() == null)
             {
-                result.Enrich(activityValueFlatten.Path.Value, activityValueFlatten.GetValue());
+                throw new InvalidOperationException("Key cannot be null");
             }
 
-            return result;
+            Enrich(entry.Key.ToString()!, entry.Value);
         }
+    }
 
-        public void Freeze()
+    public void Enrich(string path, object? value)
+    {
+        if (_frozen)
+            throw new InvalidOperationException($"{nameof(ActivityValues)} frozen");
+
+        var jPath = new JsonPath(path);
+
+        JsonNode current = Value;
+        for (int i = 0; i < jPath.Path.Length; i++)
         {
-            _frozen = true;
-        }
+            var item = jPath.Path[i];
 
-        public ActivityValueScalar[] Flatten()
-        {
-            return ActivityValueFlattener.Flatten(Value);
-        }
-
-        public void Enrich(string path, object? value)
-        {
-            if (_frozen)
-                throw new InvalidOperationException($"{nameof(ActivityValues)} frozen");
-
-            var jPath = new JsonPath(path);
-
-            JsonNode current = Value;
-            for (int i = 0; i < jPath.Path.Length; i++)
+            if (i == jPath.Path.Length - 1)
             {
-                var item = jPath.Path[i];
-
-                if (i == jPath.Path.Length - 1)
-                {
-                    AppendValue(current, item, value);
-                    break;
-                }
-
-                var newCurrent = item.IsIndex
-                    ? current.AsArray().Count <= item.Index ? null : current.AsArray()[item.Index]
-                    : current[item.Value];
-
-                if (newCurrent == null)
-                {
-                    var next = jPath.Path[i + 1];
-                    var newCurrentNode = next.IsIndex ? new JsonArray() : (JsonNode)new JsonObject();
-                    Append(current, item, newCurrentNode);
-                    current = newCurrentNode;
-                }
-                else
-                {
-                    current = newCurrent;
-                }
-            }
-        }
-
-        private void AppendValue(JsonNode node, JsonPath.Item path, object? value)
-        {
-            if (value == null || value.GetType().IsPrimitive || value is string || value is Guid)
-            {
-                Append(node, path, JsonValue.Create(value));
-                return;
+                AppendValue(current, item, value);
+                break;
             }
 
-            if (value is IEnumerable)
+            var newCurrent = item.IsIndex
+                ? current.AsArray().Count <= item.Index ? null : current.AsArray()[item.Index]
+                : current[item.Value];
+
+            if (newCurrent == null)
             {
-                Append(node, path, JsonArray.Create(JsonSerializer.SerializeToElement(value)));
-                return;
-            }
-
-            Append(node, path, JsonObject.Create(JsonSerializer.SerializeToElement(value)));
-        }
-
-        private void Append(JsonNode node, JsonPath.Item path, JsonNode? value)
-        {
-            if (path.IsIndex)
-            {
-                var jArray = node.AsArray();
-                AssertValidIndex(jArray, path.Index);
-
-                if (path.Index == jArray.Count)
-                {
-                    jArray.Add(value);
-                }
-                else
-                {
-                    jArray[path.Index] = value;
-                }
+                var next = jPath.Path[i + 1];
+                var newCurrentNode = next.IsIndex ? new JsonArray() : (JsonNode)new JsonObject();
+                Append(current, item, newCurrentNode);
+                current = newCurrentNode;
             }
             else
             {
-                var jObject = node.AsObject();
-                jObject[path.Value] = value;
+                current = newCurrent;
             }
         }
+    }
 
-        private void AssertValidIndex(JsonArray jArray, int index)
+    private void AppendValue(JsonNode node, JsonPath.Item path, object? value)
+    {
+        if (IsPrimitive(value))
         {
-            if (index < 0 || index > jArray.Count)
-            {
-                throw new ArgumentOutOfRangeException();
-            }
+            Append(node, path, JsonValue.Create(value));
+            return;
         }
 
-        public T? Get<T>(string path, T? defaultValue = default(T))
+        if (value is IEnumerable and not IDictionary)
         {
-            var jPath = new JsonPath(path);
+            Append(node, path, JsonArray.Create(JsonSerializer.SerializeToElement(value)));
+            return;
+        }
 
-            JsonNode? current = Value;
+        Append(node, path, JsonObject.Create(JsonSerializer.SerializeToElement(value)));
+    }
 
-            for (int i = 0; i < jPath.Path.Length; i++)
+    private bool IsPrimitive(object? value)
+    {
+        return value == null || value.GetType().IsPrimitive ||
+               PrimitiveSerializableReferenceTypes.Contains(value.GetType());
+    }
+
+    private void Append(JsonNode node, JsonPath.Item path, JsonNode? value)
+    {
+        if (path.IsIndex)
+        {
+            var jArray = node.AsArray();
+            AssertValidIndex(jArray, path.Index);
+
+            if (path.Index == jArray.Count)
             {
-                if (current == null)
-                {
-                    return defaultValue;
-                }
-
-                var item = jPath.Path[i];
-
-                if (item.IsIndex)
-                {
-                    current = current.AsArray()[item.Index];
-                }
-                else
-                {
-                    current = current[item.Value];
-                }
+                jArray.Add(value);
             }
+            else
+            {
+                jArray[path.Index] = value;
+            }
+        }
+        else
+        {
+            var jObject = node.AsObject();
+            jObject[path.Value] = value;
+        }
+    }
 
+    private void AssertValidIndex(JsonArray jArray, int index)
+    {
+        if (index < 0 || index > jArray.Count)
+        {
+            throw new ArgumentOutOfRangeException();
+        }
+    }
+
+    public T? Get<T>(string path, T? defaultValue = default(T))
+    {
+        var jPath = new JsonPath(path);
+
+        JsonNode? current = Value;
+
+        for (int i = 0; i < jPath.Path.Length; i++)
+        {
             if (current == null)
             {
                 return defaultValue;
             }
 
-            return current.Deserialize<T>() ?? defaultValue;
+            var item = jPath.Path[i];
+
+            if (item.IsIndex)
+            {
+                current = current.AsArray()[item.Index];
+            }
+            else
+            {
+                current = current[item.Value];
+            }
         }
+
+        if (current == null)
+        {
+            return defaultValue;
+        }
+
+        return current.Deserialize<T>() ?? defaultValue;
     }
 }

--- a/src/Webinex.Activity.Values/IActivityValue.cs
+++ b/src/Webinex.Activity.Values/IActivityValue.cs
@@ -1,33 +1,10 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿namespace Webinex.Activity;
 
-namespace Webinex.Activity
+public interface IActivityValue
 {
-    public interface IActivityValue
-    {
-        string Id { get; }
-        string Kind { get; }
-        string? ParentId { get; }
-        IActivitySystemValues SystemValues { get; }
-        ActivityValues Values { get; }
-    }
-
-    public static class ActivityValueExtensions
-    {
-        public static T? Get<T>([NotNull] this IActivityValue value, [NotNull] string path, T? defaultValue = default(T))
-        {
-            value = value ?? throw new ArgumentNullException(nameof(value));
-            path = path ?? throw new ArgumentNullException(nameof(path));
-
-            return value.Values.Get(path, defaultValue);
-        }
-
-        public static void Enrich([NotNull] this IActivityValue value, [NotNull] string path, object val)
-        {
-            value = value ?? throw new ArgumentNullException(nameof(value));
-            path = path ?? throw new ArgumentNullException(nameof(path));
-
-            value.Values.Enrich(path, val);
-        }
-    }
+    string Id { get; }
+    string Kind { get; }
+    string? ParentId { get; }
+    IActivitySystemValues SystemValues { get; }
+    ActivityValues Values { get; }
 }


### PR DESCRIPTION
2.1.1

### Added:
- Enrich with object (also includes support of anonymous types)
- Enrich with dictionary
- Ability to add activity without creating context (`IActivityScope.Add` method)
- Default ActivitySaveChangesInterceptor
- Added ability to modified entity values equality

### Fixes
- Enrich with DateOnly, TimeOnly, DateTime, DateTimeOffset, TimeSpan, Uri

### Changed

- Delete EntityChange doesn't contain OriginalValues anymore, Values would be filled in with OriginalValues